### PR TITLE
Use Git repository relative to current buffer path (fix autochdir issues)

### DIFF
--- a/autoload/vcsjump.vim
+++ b/autoload/vcsjump.vim
@@ -10,7 +10,7 @@ endfunction
 
 function! vcsjump#jump(command) abort
   let l:command=join(map(split(a:command), 'shellescape(v:val)'))
-  cexpr system(s:jump_path . ' ' . l:command . ' 2> /dev/null')
+  cexpr system(s:jump_path . ' ' . l:command . ' ' . expand("%:p:h") . ' 2> /dev/null')
   call s:set_title('vcs-jump ' . a:command)
   cwindow
 endfunction

--- a/bin/vcs-jump
+++ b/bin/vcs-jump
@@ -46,12 +46,6 @@ def absolutize(file)
   Pathname.new(file).realpath
 end
 
-def relativize(file)
-  return file if git?
-  relative = pwd.relative_path_from(root).to_s
-  file.to_s.sub("#{relative}/", '')
-end
-
 def git_root
   root = `git rev-parse --show-toplevel 2> /dev/null`.chomp
   [absolutize(root), 'git'] if $?.success?
@@ -103,13 +97,13 @@ end
 
 def mode_diff(args)
   args = shellescape(args)
-  diff =  git? ? `git diff --no-color --relative #{args}` : `hg diff --git --root . #{args}`
+  diff =  git? ? `git diff --no-color #{args}` : `hg diff --git --root . #{args}`
   idx  = nil
   file = nil
 
   diff.lines.each do |line|
     # setting the inner Perl hacker free since 2007
-    (line =~ %r{^\+\+\+ b/(.*)}) ? (file = relativize($~[1])) : (next unless file)
+    (line =~ %r{^\+\+\+ b/(.*)}) ? (file = absolutize($~[1])) : (next unless file)
     (line =~ %r{^@@ .*\+(\d+)}) ? (idx = $~[1].to_i) : (next unless idx)
     (line =~ %r{^ }) && (idx += 1; next)
     (line =~ %r{^[-+]\s*(.*)}) && ( puts "#{file}:#{idx}: #{$~[1]}"; idx = nil)
@@ -152,6 +146,8 @@ if ARGV.count < 1
 end
 
 mode = ARGV.shift
+FileUtils.cd(ARGV.shift)
+FileUtils.cd(root)
 
 if STDOUT.tty?
   begin


### PR DESCRIPTION
This PR proposes to use the path of the current buffer instead of using the `cwd` to locate the related repository. This has the benefit of working with any opened buffers wherever they are located on the system. The main repository implementation looks up for the repository in the `cwd` ( up to the system root folder). It assumed the user would start Vim in a folder and only consume files from the same repository. This is not my case. I usually open files from many repositories withing the same Vim session. Also, this PR makes the plugin usable for people opting for Vim's `autochdir` setting.

*Notes for reviewers*: 
-  The `vcs-jump` binaries now expect the path of the current buffer as a parameter. I'm not 100% is this would conflict with other features or expected workflows. My manual testing showed everything is fine but I focused my attention on the `merge` command.

Thank you @wincent for considering this PR!