### PR TITLE
Support buffers outside of Vim's CWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Other contributors that have submitted patches include (in alphabetical order):
 
 - Provide a meaningful title for the <strong>`quickfix`</strong> listing.
 - Run `git diff` with `--no-color` to prevent a `git config color.ui` setting of &quot;always&quot; from breaking diff mode (https://github.com/wincent/vcs-jump/issues/1)
+- Add <strong>[`g:VcsJumpMode`](#user-content-gvcsjumpmode)</strong> and teach <strong>[`:VcsJump`](#user-content-vcsjump)</strong> to accept a <strong>`:command-bang`</strong> suffix that can be used to make vcs-jump operate relative to the current buffer instead of the current working directory (patch from Pascal Lalancette, https://github.com/wincent/vcs-jump/pull/5).
 
 
 ### 0.1 (2 June 2019)<a name="vcs-jump-01-2-june-2019" href="#user-content-vcs-jump-01-2-june-2019"></a>

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Subcommands are:
 - &quot;merge&quot;: Results are merge conflicts. Arguments are ignored.
 - &quot;grep&quot;: Results are grep hits. Arguments are given to the underlying Git or Mercurial `grep` command.
 
+When called with a trailing <strong>`:command-bang`</strong> (eg. `:VcsJump!`) the current value of the <strong>[`g:VcsJumpMode`](#user-content-gvcsjumpmode)</strong> setting is inverted for the duration of that invocation.
+
 
 ## Mappings<a name="vcs-jump-mappings" href="#user-content-vcs-jump-mappings"></a>
 
@@ -62,6 +64,20 @@ nmap <Leader>g <Plug>(VcsJump)
 
 
 ## Options<a name="vcs-jump-options" href="#user-content-vcs-jump-options"></a>
+
+<p align="right"><a name="gvcsjumpmode" href="#user-content-gvcsjumpmode"><code>g:VcsJumpMode</code></a></p>
+
+### `g:VcsJumpMode` (string, default: "cwd")<a name="vcs-jump-gvcsjumpmode-string-default-cwd" href="#user-content-vcs-jump-gvcsjumpmode-string-default-cwd"></a>
+
+Controls whether vcs-jump should operate relative to Vim's current working directory (when <strong>[`g:VcsJumpMode`](#user-content-gvcsjumpmode)</strong> is &quot;cwd&quot;, the default) or to the current buffer (when <strong>[`g:VcsJumpMode`](#user-content-gvcsjumpmode)</strong> is &quot;buffer&quot;).
+
+To override the default, add this to your <strong>`.vimrc`</strong>:
+
+```
+let g:VcsJumpMode="buffer"
+```
+
+Note that you can temporarily invert the sense of this setting by running <strong>[`:VcsJump`](#user-content-vcsjump)</strong> with a trailing <strong>`:command-bang`</strong> (eg. `:VcsJump!`).
 
 <p align="right"><a name="gvcsjumploaded" href="#user-content-gvcsjumploaded"><code>g:VcsJumpLoaded</code></a></p>
 

--- a/autoload/vcsjump.vim
+++ b/autoload/vcsjump.vim
@@ -10,7 +10,10 @@ endfunction
 
 function! vcsjump#jump(command) abort
   let l:command=join(map(split(a:command), 'shellescape(v:val)'))
-  cexpr system('cd '. expand("%:p:h:S") . ' && ' . s:jump_path . ' ' . l:command . ' 2> /dev/null')
+  cexpr system(
+        \   'cd ' . expand("%:p:h:S") . ' && ' .
+        \   s:jump_path . ' ' . l:command . ' 2> /dev/null'
+        \ )
   call s:set_title('vcs-jump ' . a:command)
   cwindow
 endfunction

--- a/autoload/vcsjump.vim
+++ b/autoload/vcsjump.vim
@@ -10,7 +10,7 @@ endfunction
 
 function! vcsjump#jump(command) abort
   let l:command=join(map(split(a:command), 'shellescape(v:val)'))
-  cexpr system(s:jump_path . ' ' . l:command . ' 2> /dev/null')
+  cexpr system('cd '. expand("%:p:h:S") . ' && ' . s:jump_path . ' ' . l:command . ' 2> /dev/null')
   call s:set_title('vcs-jump ' . a:command)
   cwindow
 endfunction

--- a/autoload/vcsjump.vim
+++ b/autoload/vcsjump.vim
@@ -8,10 +8,29 @@ function! s:set_title(title)
   endif
 endfunction
 
-function! vcsjump#jump(command) abort
+function! vcsjump#jump(bang, command) abort
+  ""
+  " @option g:VcsJumpMode string "cwd"
+  "
+  " Controls whether vcs-jump should operate relative to Vim's current working
+  " directory (when |g:VcsJumpMode| is "cwd", the default) or to the current
+  " buffer (when |g:VcsJumpMode| is "buffer").
+  "
+  " To override the default, add this to your |.vimrc|:
+  "
+  " ```
+  " let g:VcsJumpMode="buffer"
+  " ```
+  "
+  " Note that you can temporarily invert the sense of this setting by running
+  " |:VcsJump| with a trailing |:command-bang| (eg. `:VcsJump!`).
+  "
+  let l:buffer_mode=get(g:, 'VcsJumpMode', 'cwd') ==# 'buffer'
+  let l:buffer_mode=a:bang ? !l:buffer_mode : l:buffer_mode
+  let l:cd=l:buffer_mode ? 'cd ' . expand("%:p:h:S") . ' && ' : ''
   let l:command=join(map(split(a:command), 'shellescape(v:val)'))
   cexpr system(
-        \   'cd ' . expand("%:p:h:S") . ' && ' .
+        \   l:cd .
         \   s:jump_path . ' ' . l:command . ' 2> /dev/null'
         \ )
   call s:set_title('vcs-jump ' . a:command)

--- a/doc/vcs-jump.txt
+++ b/doc/vcs-jump.txt
@@ -191,6 +191,10 @@ master (not yet released) ~
 - Run `git diff` with `--no-color` to prevent a `git config color.ui` setting of
   "always" from breaking diff mode
   (https://github.com/wincent/vcs-jump/issues/1)
+- Add |g:VcsJumpMode| and teach |:VcsJump| to accept a |:command-bang| suffix that
+  can be used to make vcs-jump operate relative to the current buffer
+  instead of the current working directory (patch from Pascal Lalancette,
+  https://github.com/wincent/vcs-jump/pull/5).
 
 0.1 (2 June 2019) ~
 

--- a/doc/vcs-jump.txt
+++ b/doc/vcs-jump.txt
@@ -56,6 +56,9 @@ Subcommands are:
 - "grep": Results are grep hits. Arguments are given to the underlying Git
   or Mercurial `grep` command.
 
+When called with a trailing |:command-bang| (eg. `:VcsJump!`) the current value
+of the |g:VcsJumpMode| setting is inverted for the duration of that invocation.
+
 MAPPINGS                                                     *vcs-jump-mappings*
 
 
@@ -74,6 +77,21 @@ You can create a different mapping like this:
     nmap <Leader>g <Plug>(VcsJump)
 <
 OPTIONS                                                       *vcs-jump-options*
+
+
+                                                                 *g:VcsJumpMode*
+|g:VcsJumpMode|                                          string (default: "cwd")
+
+Controls whether vcs-jump should operate relative to Vim's current working
+directory (when |g:VcsJumpMode| is "cwd", the default) or to the current
+buffer (when |g:VcsJumpMode| is "buffer").
+
+To override the default, add this to your |.vimrc|:
+>
+    let g:VcsJumpMode="buffer"
+<
+Note that you can temporarily invert the sense of this setting by running
+|:VcsJump| with a trailing |:command-bang| (eg. `:VcsJump!`).
 
 
                                                                *g:VcsJumpLoaded*

--- a/plugin/vcsjump.vim
+++ b/plugin/vcsjump.vim
@@ -128,6 +128,10 @@
 " - Run `git diff` with `--no-color` to prevent a `git config color.ui` setting
 "   of "always" from breaking diff mode
 "   (https://github.com/wincent/vcs-jump/issues/1)
+" - Add |g:VcsJumpMode| and teach |:VcsJump| to accept a |:command-bang| suffix
+"   that can be used to make vcs-jump operate relative to the current buffer
+"   instead of the current working directory (patch from Pascal Lalancette,
+"   https://github.com/wincent/vcs-jump/pull/5).
 "
 " ## 0.1 (2 June 2019)
 "

--- a/plugin/vcsjump.vim
+++ b/plugin/vcsjump.vim
@@ -174,7 +174,11 @@ set cpoptions&vim
 " - "grep": Results are grep hits. Arguments are given to the underlying Git or
 "   Mercurial `grep` command.
 "
-command! -nargs=+ -complete=file VcsJump call vcsjump#jump(<q-args>)
+" When called with a trailing |:command-bang| (eg. `:VcsJump!`) the current
+" value of the |g:VcsJumpMode| setting is inverted for the duration of that
+" invocation.
+"
+command! -bang -nargs=+ -complete=file VcsJump call vcsjump#jump(<bang>0, <q-args>)
 
 if !hasmapto('<Plug>(VcsJump)') && maparg('<Leader>d', 'n') ==# ''
   ""


### PR DESCRIPTION
This is a simplification of PR #2 and add support for buffers outside of Vim's CWD when `autochdir` is not enabled. This PR resolves the last issue reported in #3 that was still present even after @wincent committed 5016306e8c7f73a45cd6d1e7c65ee067ddeea15e.

Thank you @wincent!