### PR TITLE
Fix use with git diff.mnemonicprefix configuration

### DIFF
--- a/bin/vcs-jump
+++ b/bin/vcs-jump
@@ -97,7 +97,7 @@ end
 
 def mode_diff(args)
   args = shellescape(args)
-  diff =  git? ? `git diff --no-color #{args}` : `hg diff --git #{args}`
+  diff =  git? ? `git -c diff.mnemonicprefix=no diff --no-color #{args}` : `hg diff --git #{args}`
   idx  = nil
   file = nil
 


### PR DESCRIPTION
Force git's `diff.mnemonicprefix` option to off so that file names will
be correctly parsed from the diff output.