### PR TITLE
Fix regex matching for diff output parsing.

### DIFF
--- a/bin/vcs-jump
+++ b/bin/vcs-jump
@@ -97,7 +97,7 @@ end
 
 def mode_diff(args)
   args = shellescape(args)
-  diff =  git? ? `git -c diff.mnemonicPrefix=no diff --no-color #{args}` : `hg diff --git #{args}`
+  diff =  git? ? `git -c diff.noprefix=no -c diff.mnemonicPrefix=no diff --no-color #{args}` : `hg diff --git #{args}`
   idx  = nil
   file = nil
 

--- a/bin/vcs-jump
+++ b/bin/vcs-jump
@@ -104,7 +104,7 @@ def mode_diff(args)
   diff.lines.each do |line|
     # setting the inner Perl hacker free since 2007
     (line =~ %r{^\+\+\+ b/(.*)}) ? (file = root + $~[1]) : (next unless file)
-    (line =~ %r{^@@ .*\+(\d+)}) ? (idx = $~[1].to_i) : (next unless idx)
+    (line =~ %r{^@@ .*?\+(\d+)}) ? (idx = $~[1].to_i) : (next unless idx)
     (line =~ %r{^ }) && (idx += 1; next)
     (line =~ %r{^[-+]\s*(.*)}) && ( puts "#{file}:#{idx}: #{$~[1]}"; idx = nil)
   end


### PR DESCRIPTION
Fix #8

The regex was failing for my diff output, I'm not sure the reason for the `b/` in it but let me know if this breaks something I'm unaware of. The regex I'm using is the same used in the [OG git jump command](https://github.com/git/git/blob/6d3ef5b467eccd2769f1aa1c555d317d3c8dc707/contrib/git-jump/git-jump#L29-L31).