### PR TITLE
Restore user 'cpoptions' option

### DIFF
--- a/plugin/vcsjump.vim
+++ b/plugin/vcsjump.vim
@@ -289,3 +289,6 @@ if !hasmapto('<Plug>(VcsJump)') && maparg('<Leader>d', 'n') ==# ''
 endif
 
 nnoremap <Plug>(VcsJump) :VcsJump diff<space>
+
+let &cpoptions = s:cpoptions
+unlet s:cpoptions


### PR DESCRIPTION
This plugin overwrites the 'cpoptions' option since [these lines](https://github.com/wincent/vcs-jump/pull/10/files#diff-b01672ba83b453305f4b1214e0df7f35c315f29bfd15a38e2ff20ef138007344R238-R240) modify it, but never undo it at the end of the script.